### PR TITLE
Fix for installation: missing bigmler.processing module

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+1.0.1 (2014-01-06)
+~~~~~~~~~~~~~~~~~~
+
+- Fix for missing modules during installation.
+
 1.0 (2014-01-02)
 ~~~~~~~~~~~~~~~~~~
 

--- a/bigmler/__init__.py
+++ b/bigmler/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '1.0'
+__version__ = '1.0.1'
 
 if __name__ == '__main__':
     import sys

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ distutils.core.setup(
     download_url="https://github.com/bigmlcom/bigmler",
     license="http://www.apache.org/licenses/LICENSE-2.0",
     setup_requires = [],
-    packages = ['bigmler'],
+    packages = ['bigmler', 'bigmler.processing'],
     include_package_data = True,
     install_requires = ['bigml>=1.0,<1.1.0'],
     classifiers=[


### PR DESCRIPTION
I've made a quick release with this fix
