### PR TITLE
Small improvements to multi-label extended data source

### DIFF
--- a/bigmler/processing/sources.py
+++ b/bigmler/processing/sources.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 
 import os
 import csv
+from zipfile import ZipFile, ZIP_DEFLATED
 
 import bigml.api
 import bigmler.utils as u
@@ -198,7 +199,12 @@ def multi_label_expansion(training_set, training_set_header, objective_field,
                 output.writerow(row)
             except StopIteration:
                 break
+
+    output_file_zip = "%s%sextended_%s.zip" % (output_path, os.sep, file_name)
+    with ZipFile(output_file_zip, 'w', ZIP_DEFLATED) as output_zipped_file:
+        output_zipped_file.write(output_file, file_name)
+
     if not input_flag:
         objective_field = input_reader.headers[input_reader.objective_column]
 
-    return (output_file, input_reader.get_multi_label_data())
+    return (output_file_zip, input_reader.get_multi_label_data())

--- a/bigmler/train_reader.py
+++ b/bigmler/train_reader.py
@@ -187,7 +187,7 @@ class TrainReader(object):
                     self.label_separator)
                 field_values = [value.decode("utf-8").strip() for
                                 value in field_values]
-                labels_row = [label in field_values for label in
+                labels_row = [int(label in field_values) for label in
                               self.fields_labels[field_column]]
                 row.extend(labels_row)
                 for aggregate in self.label_aggregates:


### PR DESCRIPTION
- Using 0/1 instead of using Booleans True/False in extended multi-label columns to attempt to shrink down the raw extended csv file size
- Extended data source in case of multi-label is now by default zipped to speed upload to BigML as they tend to grow large
