### PR TITLE
Remove trailing dot from URL

### DIFF
--- a/bigmler/resources.py
+++ b/bigmler/resources.py
@@ -1410,7 +1410,7 @@ def create_clusters(datasets, cluster_ids, cluster_args,
                     sys.exit("Failed to get a finished cluster: %s" %
                              str(exception))
                 clusters[0] = cluster
-            message = dated("Cluster created: %s.\n" %
+            message = dated("Cluster created: %s\n" %
                             get_url(cluster))
             log_message(message, log_file=session_file,
                         console=args.verbosity)


### PR DESCRIPTION
`bigmler cluster` outputs the URL of the created cluster with a dot at the end.

When clicking the URL from a Jupyter Notebook one reaches the 404 BigML page because of the dot.

This commit just removes the trailing dot so that the URL can be clicked without this problem.